### PR TITLE
イベントのバリデーション

### DIFF
--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -15,6 +15,9 @@ class Event extends Model
         return $this->hasMany('App\Picture');
     }
 
+    public static $rules = array(
+    );
+
     protected $fillable = [
         'title',
         'release_date',

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -27,8 +27,12 @@ class Event extends Model
 
         'release_date.required' => 'イベント公開開始日は必須項目です',
         'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-        'release_date.after' => 'イベント公開開始日は明日以降である必要があります',
-        'release_date.before' => 'イベント公開開始日はイベント公開終了日以前である必要があります',
+        'release_date.after' => 'イベント公開開始日は明日より後である必要があります',
+        'release_date.before' => 'イベント公開開始日はイベント公開終了日より前である必要があります',
+
+        'end_date.required' => 'イベント公開終了日は必須項目です',
+        'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
+        'end_date.after' => 'イベント公開終了日はイベント公開日より後である必要があります',
     ];
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -16,6 +16,7 @@ class Event extends Model
     }
 
     public static $rules = array(
+        'title' => ['required', 'max:255'],
     );
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -24,6 +24,11 @@ class Event extends Model
     public static $messages = [
         'title.required' => 'イベントタイトルは必須項目です',
         'title.max' => 'イベントタイトルは255文字まで設定できます',
+
+        'release_date.required' => 'イベント公開開始日は必須項目です',
+        'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
+        'release_date.after' => 'イベント公開開始日は明日以降である必要があります',
+        'release_date.before' => 'イベント公開開始日はイベント公開終了日以前である必要があります',
     ];
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -18,6 +18,7 @@ class Event extends Model
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after:today', 'before:end_date'],
+        'end_date' => ['required', 'date', 'after:release_date'],
     ];
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -15,9 +15,10 @@ class Event extends Model
         return $this->hasMany('App\Picture');
     }
 
-    public static $rules = array(
+    public static $rules = [
         'title' => ['required', 'max:255'],
-    );
+        'release_date' => ['required', 'date', 'after:today', 'before:end_date'],
+    ];
 
     protected $fillable = [
         'title',

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -22,6 +22,8 @@ class Event extends Model
     ];
 
     public static $messages = [
+        'title.required' => 'イベントタイトルは必須項目です',
+        'title.max' => 'イベントタイトルは255文字まで設定できます',
     ];
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -21,6 +21,9 @@ class Event extends Model
         'end_date' => ['required', 'date', 'after:release_date'],
     ];
 
+    public static $messages = [
+    ];
+
     protected $fillable = [
         'title',
         'release_date',

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -46,6 +46,7 @@ class EventController extends Controller
      */
     public function store(Request $request)
     {
+        $this->validate($request, Event::$rules);
         $event = new \App\Event;
         $event->user_id = Auth::id();
         $form = $request->all();

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -46,7 +46,7 @@ class EventController extends Controller
      */
     public function store(Request $request)
     {
-        $this->validate($request, Event::$rules);
+        $this->validate($request, Event::$rules, Event::$messages);
 
         $form = $request->all();
         unset($form['_token']);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -39,7 +39,7 @@ class EventController extends Controller
 
     /**
      * /events/create/ のページのフォーム情報を受け取り、保存する
-     * @param $request POSTリクエストを受け取る
+     * @param $request POSTリクエストを受け取る(Eventモデルの$rulesでバリデーションを行う)
      * @param $form $requestの中からhtml側のformに格納された情報を取り出し、受け取る
      * @param $event 新規作成するEventの情報を格納する
      * @return イベント一覧画面を表示する

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -47,13 +47,17 @@ class EventController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, Event::$rules);
-        $event = new \App\Event;
-        $event->user_id = Auth::id();
+
         $form = $request->all();
         unset($form['_token']);
-        $event->fill($form);
+
+        $event = new Event;
+        $event->user_id = Auth::id();
         $event->auth_key = $this->generateHash($event->title);
+        $event->fill($form);
+
         $event->save();
+
         return redirect('events');
     }
   

--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -8,10 +8,19 @@
         @csrf
         <h3>イベント名</h3>
         <input type="text" name="title">
+        @if($errors->has('title'))
+        <p>{{ $errors->first('title') }}</p>
+        @endif
         <h3>公開開始日</h3>
         <input type="date" name="release_date">
+        @if($errors->has('release_date'))
+        <p>{{ $errors->first('release_date') }}</p>
+        @endif
         <h3>公開終了日</h3>
         <input type="date" name="end_date">
+        @if($errors->has('end_date'))
+        <p>{{ $errors->first('end_date') }}</p>
+        @endif
         <input type="submit" value="作成">
     </form>
 @endsection

--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -7,17 +7,17 @@
     <form method="POST" action="/events/">
         @csrf
         <h3>イベント名</h3>
-        <input type="text" name="title">
+        <input type="text" name="title" value="{{ old('title') }}">
         @if($errors->has('title'))
         <p>{{ $errors->first('title') }}</p>
         @endif
         <h3>公開開始日</h3>
-        <input type="date" name="release_date">
+        <input type="date" name="release_date" value="{{ old('release_date') }}">
         @if($errors->has('release_date'))
         <p>{{ $errors->first('release_date') }}</p>
         @endif
         <h3>公開終了日</h3>
-        <input type="date" name="end_date">
+        <input type="date" name="end_date" value="{{ old('end_date') }}">
         @if($errors->has('end_date'))
         <p>{{ $errors->first('end_date') }}</p>
         @endif


### PR DESCRIPTION
- #58 イベント保存時のバリデーション機能を追加しました
  - バリデーションの内容はEventモデルに、バリデーションの処理はEventControllerに記述しています
- [#64で頂いた修正案](https://github.com/sen-newface/msm-yeahcheese/pull/64#pullrequestreview-410672802) #65 EventControllerのstore関数のリファクタを行いました

バリデーションを通った場合はイベントが保存されてindexにリダイレクトすることを、通らなかった場合は保存せずに作成ページに留まることを確認しています。
レビューよろしくお願いします。