### PR TITLE
middlewareを使って非ログインユーザが閲覧できるページを制限

### DIFF
--- a/yeahcheese/routes/web.php
+++ b/yeahcheese/routes/web.php
@@ -20,12 +20,11 @@ Route::get('/', function () {
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index')->name('home');
 Route::prefix('events')->group(function () {
-    Route::get('/', 'EventController@index')->name('events.index');
-    Route::get('create', 'EventController@create')->name('events.create');
-    Route::post('/', 'EventController@store')->name('events.store');
-    Route::get('update', 'EventController@update')->name('events.update');
+    Route::get('/', 'EventController@index')->name('events.index')->middleware('auth');
+    Route::get('create', 'EventController@create')->name('events.create')->middleware('auth');
+    Route::post('/', 'EventController@store')->name('events.store')->middleware('auth');
+    Route::get('update', 'EventController@update')->name('events.update')->middleware('auth');
     # テスト表示用なのでputは用意しません
     Route::get('search', 'EventController@search')->name('events.search');
     Route::post('show', 'EventController@show')->name('events.show');


### PR DESCRIPTION
#75 
- ルーティングを編集して閲覧に制限をかけました
  - ログインしていないユーザが制限されているページにアクセスするとログイン画面にリダイレクトされます

手元の環境で動作確認済みです。
レビューよろしくお願いいたします。