### PR TITLE
[fix]バリデーションの内容とエラーメッセージの修正

### DIFF
--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -32,6 +32,7 @@ class Event extends Model
 
         'end_date.required' => 'イベント公開終了日は必須項目です',
         'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
+        'end_date.after' => 'イベント公開開始日は明日より後である必要があります',
         'end_date.after' => 'イベント公開終了日はイベント公開日より後である必要があります',
     ];
 

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -18,7 +18,7 @@ class Event extends Model
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after:today', 'before:end_date'],
-        'end_date' => ['required', 'date', 'after:release_date'],
+        'end_date' => ['required', 'date', 'after:today', 'after:release_date'],
     ];
 
     public static $messages = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -33,7 +33,7 @@ class Event extends Model
         'end_date.required' => 'イベント公開終了日は必須項目です',
         'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
         'end_date.after' => 'イベント公開開始日は明日より後の日付である必要があります',
-        'end_date.after' => 'イベント公開終了日はイベント公開日より後の日付である必要があります',
+        'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
     ];
 
     protected $fillable = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -18,7 +18,7 @@ class Event extends Model
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today', 'before:end_date'],
-        'end_date' => ['required', 'date', 'after:today', 'after:release_date'],
+        'end_date' => ['required', 'date', 'after:release_date'],
     ];
 
     public static $messages = [
@@ -32,7 +32,6 @@ class Event extends Model
 
         'end_date.required' => 'イベント公開終了日は必須項目です',
         'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-        'end_date.after' => 'イベント公開開始日は明日より後の日付である必要があります',
         'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
     ];
 

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -27,7 +27,7 @@ class Event extends Model
 
         'release_date.required' => 'イベント公開開始日は必須項目です',
         'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-        'release_date.after' => 'イベント公開開始日は明日より後である必要があります',
+        'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
         'release_date.before' => 'イベント公開開始日はイベント公開終了日より前である必要があります',
 
         'end_date.required' => 'イベント公開終了日は必須項目です',

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -17,7 +17,7 @@ class Event extends Model
 
     public static $rules = [
         'title' => ['required', 'max:255'],
-        'release_date' => ['required', 'date', 'after_or_equal:today', 'before:end_date'],
+        'release_date' => ['required', 'date', 'after_or_equal:today'],
         'end_date' => ['required', 'date', 'after:release_date'],
     ];
 
@@ -28,7 +28,6 @@ class Event extends Model
         'release_date.required' => 'イベント公開開始日は必須項目です',
         'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
         'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
-        'release_date.before' => 'イベント公開開始日はイベント公開終了日より前の日付である必要があります',
 
         'end_date.required' => 'イベント公開終了日は必須項目です',
         'end_date.date' => 'イベント公開終了日は日付形式で入力してください',

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -17,7 +17,7 @@ class Event extends Model
 
     public static $rules = [
         'title' => ['required', 'max:255'],
-        'release_date' => ['required', 'date', 'after:today', 'before:end_date'],
+        'release_date' => ['required', 'date', 'after_or_equal:today', 'before:end_date'],
         'end_date' => ['required', 'date', 'after:today', 'after:release_date'],
     ];
 

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -28,12 +28,12 @@ class Event extends Model
         'release_date.required' => 'イベント公開開始日は必須項目です',
         'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
         'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
-        'release_date.before' => 'イベント公開開始日はイベント公開終了日より前である必要があります',
+        'release_date.before' => 'イベント公開開始日はイベント公開終了日より前の日付である必要があります',
 
         'end_date.required' => 'イベント公開終了日は必須項目です',
         'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-        'end_date.after' => 'イベント公開開始日は明日より後である必要があります',
-        'end_date.after' => 'イベント公開終了日はイベント公開日より後である必要があります',
+        'end_date.after' => 'イベント公開開始日は明日より後の日付である必要があります',
+        'end_date.after' => 'イベント公開終了日はイベント公開日より後の日付である必要があります',
     ];
 
     protected $fillable = [

--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -21,6 +21,10 @@
         @if($errors->has('end_date'))
         <p>{{ $errors->first('end_date') }}</p>
         @endif
+        @if($errors->any())
+        <hr>
+        <p>入力した値が正しくありません。</p>
+        @endif
         <input type="submit" value="作成">
     </form>
 @endsection


### PR DESCRIPTION
#80 についてのPRです。

- 日付関連のバリデーションがわかりにくく、また内容がかぶっている部分があったので修正しました
  - 公開開始日のバリデーション内容を「明日以降」から「今日以降」に変更しました
  - 公開終了日のバリデーション内容から「明日以降」を削除しました
- 上記に伴ってエラーメッセージも修正しています
- フォームにおいて、個別のエラーメッセージのほかに、フォームの値のどれかが正しくないというメッセージを作成ボタン上部に表示するようにしました

手元の環境で動作確認を行っています。
レビューよろしくお願いいたします。