### PR TITLE
[fix]イベント一覧画面でスコープを使って検索するように変更

### DIFF
--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -33,7 +33,7 @@ class Event extends Model
 
     public function scopeReleaseDateAfter($query, $date)
     {
-    
+        return $query->where('release_date', '>', $date);
     }
 
     public static $rules = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -18,7 +18,7 @@ class Event extends Model
 
     public function scopeUserIdEquals($query, $id)
     {
-    
+        return $query->where('id', '==', $id);
     }
 
     public static $rules = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -18,7 +18,7 @@ class Event extends Model
 
     public function scopeUserIdEquals($query, $id)
     {
-        return $query->where('id', '==', $id);
+        return $query->where('user_id', $id);
     }
 
     public static $rules = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -28,7 +28,7 @@ class Event extends Model
 
     public function scopeEndDateBefore($query, $date)
     {
-    
+        return $query->where('end_date', '<', $date);
     }
 
     public static $rules = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -38,7 +38,7 @@ class Event extends Model
 
     public function scopeReleaseDateBefore($query, $date)
     {
-
+        return $query->where('release_date', '<', $date);
     }
 
     public static $rules = [

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -21,6 +21,11 @@ class Event extends Model
         return $query->where('user_id', $id);
     }
 
+    public function scopeEndDateAfter($query, $date)
+    {
+    
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -36,6 +36,11 @@ class Event extends Model
         return $query->where('release_date', '>', $date);
     }
 
+    public function scopeReleaseDateBefore($query, $date)
+    {
+
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -16,6 +16,11 @@ class Event extends Model
         return $this->hasMany('App\Picture');
     }
 
+    public function scopeUserIdEquals($query, $id)
+    {
+    
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -23,7 +23,7 @@ class Event extends Model
 
     public function scopeEndDateAfter($query, $date)
     {
-    
+        return $query->where('end_date', '>', $date);
     }
 
     public function scopeEndDateBefore($query, $date)

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -26,6 +26,11 @@ class Event extends Model
     
     }
 
+    public function scopeEndDateBefore($query, $date)
+    {
+    
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -31,6 +31,11 @@ class Event extends Model
         return $query->where('end_date', '<', $date);
     }
 
+    public function scopeReleaseDateAfter($query, $date)
+    {
+    
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -10,6 +10,7 @@ class Event extends Model
     {
         return $this->belongsTo('App\User');
     }
+
     public function pictures()
     {
         return $this->hasMany('App\Picture');

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Event;
-use \App\Picture;
 
 class EventController extends Controller
 {

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -14,7 +14,8 @@ class EventController extends Controller
     {
         $today = CarbonImmutable::now()->toDateString();
         $id = Auth::id();
-        $events = Event::where('user_id', $id)->with('pictures')->get();
+        // $events = Event::where('user_id', $id)->with('pictures')->get();
+        $events = Event::userIdEquals($id)->with('pictures')->get();
         return view('events_list', ['events' => $events, 'today' => $today]);
     }
 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -6,17 +6,17 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Event;
 use \App\Picture;
-use Carbon\CarbonImmutable;
 
 class EventController extends Controller
 {
     public function index()
     {
-        $today = CarbonImmutable::now()->toDateString();
         $id = Auth::id();
-        // $events = Event::where('user_id', $id)->with('pictures')->get();
-        $events = Event::userIdEquals($id)->with('pictures')->get();
-        return view('events_list', ['events' => $events, 'today' => $today]);
+        $events = Event::userIdEquals($id)
+            ->with('pictures')
+            ->get();
+
+        return view('events_list', ['events' => $events]);
     }
 
     /**

--- a/yeahcheese/resources/views/events_list.blade.php
+++ b/yeahcheese/resources/views/events_list.blade.php
@@ -9,13 +9,11 @@
     </a>
     <!-- $eventsはで現在のユーザが作成したイベントの配列が渡される想定です -->
     @foreach($events as $event)
-        @if($event->end_date >= $today)
-            <div>
-                <h3>{{ $event->title }}</h3>
-                <p>掲載期間：{{ $event->release_date }} - {{ $event->end_date }} 枚数：{{ $event->pictures->count() }}／キー：{{ $event->auth_key }}
-                    <a href="{{ route('events.update') }}">編集する</a>
-                </p>
-            </div>
-        @endif
+        <div>
+            <h3>{{ $event->title }}</h3>
+            <p>掲載期間：{{ $event->release_date }} - {{ $event->end_date }} 枚数：{{ $event->pictures->count() }}／キー：{{ $event->auth_key }}
+                <a href="{{ route('events.update') }}">編集する</a>
+            </p>
+        </div>
     @endforeach
 @endsection


### PR DESCRIPTION
#96 
- 検索や絞り込みをスコープで行えるようにしました
  - これに伴ってblade.phpで期間外の表示をしないようにする処理を削除しました
- 追加したイベントスコープは下記の通りです
  - ユーザーIDでの絞り込み
  - 公開開始日が指定日より前/後であるか
  - 公開終了日が指定日より前/後であるか
- 修正中にイベント一覧画面で日付での絞り込みは不要ではないかという結論になり、現状の画面では絞り込みはしていません（機能だけある状態です）

手元で公開開始日のスコープは動作確認しています。
レビューよろしくお願いいたします。