### PR TITLE
イベント表示ページに複数の改修

### DIFF
--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -51,6 +51,11 @@ class Event extends Model
         return $query->where('release_date', '<', $date);
     }
 
+    public function scopeReleaseDateBeforeOrEquals($query, $date)
+    {
+        return $query->where('release_date', '<=', $date);
+    }
+
     public static $rules = [
         'title' => ['required', 'max:255'],
         'release_date' => ['required', 'date', 'after_or_equal:today'],

--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -36,6 +36,11 @@ class Event extends Model
         return $query->where('end_date', '<', $date);
     }
 
+    public function scopeEndDateBeforeOrEquals($query, $date)
+    {
+        return $query->where('end_date', '<=', $date);
+    }
+
     public function scopeReleaseDateAfter($query, $date)
     {
         return $query->where('release_date', '>', $date);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -66,7 +66,7 @@ class EventController extends Controller
     // TODO: resquestに認証キー
     public function show(Request $request)
     {
-        $event = Event::where('auth_key', $request->auth_key)->first();
+        $event = Event::AuthKeyEquals($request->auth_key)->first();
         if(is_null($event))
         {
             $pictures = null;

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -67,7 +67,6 @@ class EventController extends Controller
     // TODO: resquestに認証キー
     public function show(Request $request)
     {
-
         $today = CarbonImmutable::now()->toDateString();
 
         $event = Event::AuthKeyEquals($request->auth_key)
@@ -81,7 +80,7 @@ class EventController extends Controller
             return view('event', [
                 'event' => $event,
                 'pictures' => $pictures,
-            ]);
+            ])->with($request->auth_key);
         } else {
             return redirect('events/search');
         }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -70,7 +70,7 @@ class EventController extends Controller
         $today = CarbonImmutable::now()->toDateString();
 
         $event = Event::authKeyEquals($request->auth_key)
-            ->releaseDateBefore($today)
+            ->releaseDateBeforeOrEquals($today)
             ->endDateAfter($today)
             ->first();
 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -69,9 +69,9 @@ class EventController extends Controller
     {
         $today = CarbonImmutable::now()->toDateString();
 
-        $event = Event::AuthKeyEquals($request->auth_key)
-            ->ReleaseDateBefore($today)
-            ->EndDateAfter($today)
+        $event = Event::authKeyEquals($request->auth_key)
+            ->releaseDateBefore($today)
+            ->endDateAfter($today)
             ->first();
 
         if (!is_null($event)) {

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -75,18 +75,16 @@ class EventController extends Controller
             ->EndDateAfter($today)
             ->first();
 
-        if(!is_null($event))
-        {
+        if (!is_null($event)) {
             $pictures = $event->pictures()->get();
 
             return view('event', [
-                'event' => $event, 
+                'event' => $event,
                 'pictures' => $pictures,
             ]);
         } else {
             return redirect('events/search');
         }
-
     }
 
     public function search()

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -67,13 +67,19 @@ class EventController extends Controller
     public function show(Request $request)
     {
         $event = Event::AuthKeyEquals($request->auth_key)->first();
-        if(is_null($event))
+
+        if(!is_null($event))
         {
-            $pictures = null;
-        } else {
             $pictures = $event->pictures();
+
+            return view('event', [
+                'event' => $event, 
+                'pictures' => $pictures,
+            ]);
+        } else {
+            return redirect('events/search');
         }
-        return view('event', compact('event', 'pictures'));
+
     }
 
     public function search()

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -70,7 +70,7 @@ class EventController extends Controller
 
         if(!is_null($event))
         {
-            $pictures = $event->pictures();
+            $pictures = $event->pictures()->get();
 
             return view('event', [
                 'event' => $event, 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Carbon\CarbonImmutable;
 use App\Event;
 
 class EventController extends Controller
@@ -66,7 +67,13 @@ class EventController extends Controller
     // TODO: resquestに認証キー
     public function show(Request $request)
     {
-        $event = Event::AuthKeyEquals($request->auth_key)->first();
+
+        $today = CarbonImmutable::now()->toDateString();
+
+        $event = Event::AuthKeyEquals($request->auth_key)
+            ->ReleaseDateBefore($today)
+            ->EndDateAfter($today)
+            ->first();
 
         if(!is_null($event))
         {

--- a/yeahcheese/resources/views/event.blade.php
+++ b/yeahcheese/resources/views/event.blade.php
@@ -4,17 +4,12 @@
 
 @section('content')
     <div>
-    @if(!is_null($event))
         <h2>{{ $event->title }}</h2><!-- eventのタイトル -->
         <!-- 写真一覧表示 -->
         @foreach($pictures as $picture)
         <div>
-            <!-- events.id == pictures.event_idのpictures.path -->
             <img src="{{ \Storage::url($picture->path) }}" style="width:250px">
         </div>
         @endforeach
-    @else
-        <h2>イベントが見つかりませんでした</h2>
-    @endif
     </div>
 @endsection

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -6,7 +6,7 @@
     <h2>イベント閲覧</h2>
     <h1>認証キー入力</h1>
     <div>
-        <form method="post" action="{{ route('events.show') }}">
+        <form method="GET" action="{{ route('events.show') }}">
             @csrf
             <input type="text" name="auth_key" placeholder="認証キーを入力">
             <button type="submit">閲覧</button>

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -7,7 +7,6 @@
     <h1>認証キー入力</h1>
     <div>
         <form method="GET" action="{{ route('events.show') }}">
-            @csrf
             <input type="text" name="auth_key" placeholder="認証キーを入力">
             <button type="submit">閲覧</button>
         </form>

--- a/yeahcheese/routes/web.php
+++ b/yeahcheese/routes/web.php
@@ -29,5 +29,5 @@ Route::prefix('events')->group(function () {
     });
     # テスト表示用なのでputは用意しません
     Route::get('search', 'EventController@search')->name('events.search');
-    Route::post('show', 'EventController@show')->name('events.show');
+    Route::get('show', 'EventController@show')->name('events.show');
 });


### PR DESCRIPTION
- イベント表示ページのURLはこれまで/events/show/と表示されていましたが、/events/show?auth_key=12345678のように表示するように変更しました。 #95 
  - /events/search/経由だけでなく、/events/show?auth_key="認証キー"形式でも各イベントの詳細ページへアクセスできるようになります
  - この変更に伴って、showへのアクセスはPOSTリクエストではなくGETリクエストを利用するように変更しました
- 公開開始日以降公開終了日以前のイベントのみが表示されるように変更しました
- show関数のリファクタを行いました

手元の環境で意図した通りに動作することを確認しています。
レビューよろしくお願いいたします。