### PR TITLE
APIのdestroyメソッドとテストの作成

### DIFF
--- a/yeahcheese/app/Http/Controllers/Api/PictureController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PictureController.php
@@ -25,8 +25,8 @@ class PictureController extends Controller
         # code...
     }
 
-    public function destroy(Picture $picture)
+    public function destroy($picture_id)
     {
-        # code...
+        Picture::where('id', $picture_id)->delete();
     }
 }

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -27,5 +27,5 @@ Route::prefix('pictures')->group(function () {
     Route::get('/list', 'Api\PictureController@list')->name('pictures.list');
     Route::get('/fetch', 'Api\PictureController@fetch')->name('pictures.fetch');
     Route::post('/store', 'Api\PictureController@store')->name('pictures.store');
-    Route::delete('/destroy', 'Api\PictureController@destroy')->name('pictures.destroy');
+    Route::delete('/destroy/{id}', 'Api\PictureController@destroy')->name('pictures.destroy');
 });

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -27,5 +27,5 @@ Route::prefix('pictures')->group(function () {
     Route::get('/list', 'Api\PictureController@list')->name('pictures.list');
     Route::get('/fetch', 'Api\PictureController@fetch')->name('pictures.fetch');
     Route::post('/store', 'Api\PictureController@store')->name('pictures.store');
-    Route::delete('/destroy/{id}', 'Api\PictureController@destroy')->name('pictures.destroy');
+    Route::delete('/destroy/{picture_id}', 'Api\PictureController@destroy')->name('pictures.destroy');
 });

--- a/yeahcheese/tests/Feature/Api/PictureControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/PictureControllerTest.php
@@ -29,6 +29,7 @@ class PictureControllerTest extends TestCase
         $this->seed();
         $picture = Picture::find('1');
         $response = $this->deleteJson('api/pictures/destroy/'. $picture->id);
+        
         $this->assertDatabaseMissing('pictures', ['id' => '1']);
         $response->assertStatus(200);
         

--- a/yeahcheese/tests/Feature/Api/PictureControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/PictureControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Picture;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -21,5 +22,15 @@ class PictureControllerTest extends TestCase
                 ['path' => 'neko_magazine04.jpg'],
             ]
         ]);
+    }
+
+    public function testSuccessDeletePicture()
+    {
+        $this->seed();
+        $picture = Picture::find('1');
+        $response = $this->deleteJson('api/pictures/destroy/'. $picture->id);
+        $this->assertDatabaseMissing('pictures', ['id' => '1']);
+        $response->assertStatus(200);
+        
     }
 }


### PR DESCRIPTION
#15 
- ルートをapi/pictures/destroyからapi/pictures/destroy/{id}に変更。picturesのidを指定する。