### PR TITLE
イベントが見つからず検索画面にリダイレクトする際にエラーメッセージを表示する

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -82,7 +82,7 @@ class EventController extends Controller
                 'pictures' => $pictures,
             ])->with($request->auth_key);
         } else {
-            return redirect('events/search');
+            return redirect('events/search')->withErrors('イベントが見つかりませんでした。');
         }
     }
 

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -6,6 +6,11 @@
     <h2>イベント閲覧</h2>
     <h1>認証キー入力</h1>
     <div>
+    @if ($errors->any())
+        @foreach ($errors->all() as $error)
+        <p>{{ $error }}</p>
+        @endforeach
+    @endif
         <form method="GET" action="{{ route('events.show') }}">
             <input type="text" name="auth_key" placeholder="認証キーを入力">
             <button type="submit">閲覧</button>

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -7,9 +7,7 @@
     <h1>認証キー入力</h1>
     <div>
     @if ($errors->any())
-        @foreach ($errors->all() as $error)
-        <p>{{ $error }}</p>
-        @endforeach
+        <p>{{ $errors->first() }}</p>
     @endif
         <form method="GET" action="{{ route('events.show') }}">
             <input type="text" name="auth_key" placeholder="認証キーを入力">


### PR DESCRIPTION
[こちら](https://github.com/sen-newface/msm-yeahcheese/pull/116#discussion_r426408583)で頂いた改修案を反映しました

- イベント検索で対象のイベントが見つからなかった際のリダイレクトにエラーメッセージをつけました
  - 合わせてテンプレートも編集し、エラーメッセージを表示するようにしています
    - 赤くしたりした方が目につきやすそうなので、#59に対応する際にまとめて対応したいと思います

手元の環境で動作確認を行っています。
レビューよろしくお願いいたします。