### PR TITLE
getPathList APIのテストをファクトリーを使う形に変更

### DIFF
--- a/yeahcheese/tests/Feature/Api/PictureControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/PictureControllerTest.php
@@ -16,17 +16,22 @@ class PictureControllerTest extends TestCase
 
     public function testSuccessGetPathList()
     {
+
+        $data = [];
+
+        $pictures = Picture::All();
+
+        foreach($pictures as $picture) {
+            $data[] = ['path' => $picture->path];
+        }
+
+        $expect = ['data'=>$data];
+
         $response = $this->getJson('api/pictures/list');
 
         $response->assertStatus(200);
 
-        $response->assertJson([
-            'data' => [
-                ['path' => 'neko_magazine04.jpg'],
-                ['path' => 'neko_magazine04.jpg'],
-                ['path' => 'neko_magazine04.jpg'],
-            ]
-        ]);
+        $response->assertJson($expect);
     }
 
     public function testSuccessGetPath()


### PR DESCRIPTION
テスト内容をファクトリーを使う形に変更しました

getPathListのテストは動きますが、このブランチでは他のテストがエラーを出してしまうため、動作確認の際には他のテスト関数をコメントアウトする必要があります
この点については他の方のPR（#133 #135）で修正されています

レビューよろしくお願いいたします