### PR TITLE
イベント表示の際画像が1枚もない場合に、ないことを表示

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -77,6 +77,14 @@ class EventController extends Controller
         if (!is_null($event)) {
             $pictures = $event->pictures()->get();
 
+            if ($pictures->isEmpty()) 
+            {
+                return view('event', [
+                    'event' => $event,
+                    'pictures' => $pictures,
+                ])->with($request->auth_key)->withErrors('写真が登録されていません。');
+            }
+
             return view('event', [
                 'event' => $event,
                 'pictures' => $pictures,

--- a/yeahcheese/resources/views/event.blade.php
+++ b/yeahcheese/resources/views/event.blade.php
@@ -6,6 +6,9 @@
     <div>
         <h2>{{ $event->title }}</h2><!-- eventのタイトル -->
         <!-- 写真一覧表示 -->
+        @if ($errors->any())
+            <p>{{ $errors->first() }}</p>
+        @endif
         @foreach($pictures as $picture)
         <div>
             <img src="{{ \Storage::url($picture->path) }}" style="width:250px">


### PR DESCRIPTION
#85 
- EventCopntrollerのshowでイベントに紐付いた写真を取得する際になにもなかったときにviewにエラーメッセージを渡す