### PR TITLE
イベント一覧画面で表示されるサムネイルの数を最大3枚に制限

### DIFF
--- a/yeahcheese/resources/views/events_list.blade.php
+++ b/yeahcheese/resources/views/events_list.blade.php
@@ -15,10 +15,14 @@
                 <a href="{{ route('events.update') }}">編集する</a><br>
             </p>
             @foreach($event->pictures as $picture)
+                @if ($loop->iteration <= 3)
                 <div class="picture">
                     <img class="picture-thumbnail" src="{{ \Storage::url($picture->path) }}"><br>
                     Updated<br>{{ $picture->updated_at->format('Y/m/d H:i') }}
                 </div>
+                @else
+                    @break
+                @endif
             @endforeach
         </div>
     @endforeach


### PR DESCRIPTION
#128 #127 
イベント一覧画面のテンプレートを編集し、表示されるサムネイル画像の数を最大3枚に制限しました

手元の環境でイベントに紐づいている画像が0〜4枚の時の表示をそれぞれ確認しています
レビューよろしくお願いいたします