### PR TITLE
公開期間外の場合のエラーメッセージを追加

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -76,7 +76,7 @@ class EventController extends Controller
 
     public function show(Request $request)
     {
-        $today = CarbonImmutable::now();
+        $today = CarbonImmutable::today();
 
         $event = Event::authKeyEquals($request->auth_key)
             ->first();

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Carbon\CarbonImmutable;
 use App\Event;
+use DateTime;
 
 class EventController extends Controller
 {
@@ -76,15 +76,19 @@ class EventController extends Controller
 
     public function show(Request $request)
     {
-        $today = CarbonImmutable::now()->toDateString();
+        $today = new DateTime(date('Y-m-d'));
 
         $event = Event::authKeyEquals($request->auth_key)
-            ->releaseDateBeforeOrEquals($today)
-            ->endDateAfter($today)
             ->first();
 
         if (!is_null($event)) {
             $pictures = $event->pictures()->get();
+            
+            $release_date = new DateTime($event->release_date);
+            $end_date = new DateTime($event->end_date);
+            if ($today < $release_date || $today > $end_date) {
+                return redirect('events/search')->withErrors('イベントの公開期間外です。');
+            }
 
             if ($pictures->isEmpty()) 
             {

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Carbon\CarbonImmutable;
 use App\Event;
-use DateTime;
 
 class EventController extends Controller
 {
@@ -76,7 +76,7 @@ class EventController extends Controller
 
     public function show(Request $request)
     {
-        $today = new DateTime(date('Y-m-d'));
+        $today = CarbonImmutable::now();
 
         $event = Event::authKeyEquals($request->auth_key)
             ->first();
@@ -84,8 +84,8 @@ class EventController extends Controller
         if (!is_null($event)) {
             $pictures = $event->pictures()->get();
             
-            $release_date = new DateTime($event->release_date);
-            $end_date = new DateTime($event->end_date);
+            $release_date = CarbonImmutable::parse($event->release_date);
+            $end_date = CarbonImmutable::parse($event->end_date);
             if ($today < $release_date || $today > $end_date) {
                 return redirect('events/search')->withErrors('イベントの公開期間外です。');
             }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -90,7 +90,7 @@ class EventController extends Controller
                 return redirect('events/search')->withErrors('イベントの公開期間外です。');
             }
 
-            if ($pictures->isEmpty()) 
+            if ($pictures->isEmpty())
             {
                 return view('event_show', [
                     'event' => $event,


### PR DESCRIPTION
#143 
- eventを取ってくる際に期間内で絞り込むのをやめた
- eventを取ってきたあとで、release_dateとend_dateとtodayを比較して、公開期間外の場合のエラーメッセージを表示する