### PR TITLE
ESLint使用時、TypeScript用のチェックを行わないように変更

### DIFF
--- a/yeahcheese/.eslintrc.json
+++ b/yeahcheese/.eslintrc.json
@@ -10,7 +10,8 @@
   "rules": {
     "indent": ["error", 2]
   },
-  "overrides": [{
+  "overrides": [
+    {
       "files": ["*.ts"],
       "extends": [
         "plugin:@typescript-eslint/recommended"

--- a/yeahcheese/.eslintrc.json
+++ b/yeahcheese/.eslintrc.json
@@ -5,13 +5,21 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
     "plugin:vue/recommended"
   ],
   "rules": {
-    "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/indent": ["error", 2],
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off"
-  }
+    "indent": ["error", 2]
+  },
+  "overrides": [{
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "rules": {
+        "@typescript-eslint/camelcase": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-non-null-assertion": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
yeahcheese/.eslint.jsonを編集し、ESLintの設定を変更しました。

- 拡張子が.tsファイルの時のみTypeScript用のチェックを行うようにしました

手元の環境において*.js, *.ts, *vueそれぞれのファイルで動作確認を行っています。
レビューよろしくお願いいたします。