### PR TITLE
ログイン状態で'/register'に飛ぶと'/'にリダイレクト

### DIFF
--- a/yeahcheese/app/Providers/RouteServiceProvider.php
+++ b/yeahcheese/app/Providers/RouteServiceProvider.php
@@ -21,7 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/';
 
     /**
      * Define your route model bindings, pattern filters, etc.


### PR DESCRIPTION
#183 
RouteServiceProviser.phpでHOME='/home'になっていたのを修正