### PR TITLE
storeメソッドのバリデーションのFormRequest化、必要のないエラー文の削除

### DIFF
--- a/yeahcheese/app/Event.php
+++ b/yeahcheese/app/Event.php
@@ -56,25 +56,6 @@ class Event extends Model
         return $query->where('release_date', '<=', $date);
     }
 
-    public static $storeRules = [
-        'title' => ['required', 'max:255'],
-        'release_date' => ['required', 'date', 'after_or_equal:today'],
-        'end_date' => ['required', 'date', 'after:release_date'],
-    ];
-
-    public static $messages = [
-        'title.required' => 'イベントタイトルは必須項目です',
-        'title.max' => 'イベントタイトルは255文字まで設定できます',
-
-        'release_date.required' => 'イベント公開開始日は必須項目です',
-        'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-        'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
-
-        'end_date.required' => 'イベント公開終了日は必須項目です',
-        'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-        'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
-    ];
-
     protected $fillable = [
         'title',
         'release_date',

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -83,7 +83,7 @@ class EventController extends Controller
 
         if (!is_null($event)) {
             $pictures = $event->pictures()->get();
-            
+
             $release_date = CarbonImmutable::parse($event->release_date);
             $end_date = CarbonImmutable::parse($event->end_date);
             if ($today < $release_date || $today > $end_date) {

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\CarbonImmutable;
 use App\Event;
+use App\Http\Requests\StoreEventRequest;
 
 class EventController extends Controller
 {
@@ -47,10 +48,8 @@ class EventController extends Controller
      * @param $event 新規作成するEventの情報を格納する
      * @return イベント一覧画面を表示する
      */
-    public function store(Request $request)
+    public function store(StoreEventRequest $request)
     {
-        $this->validate($request, Event::$storeRules, Event::$messages);
-
         $form = $request->all();
         unset($form['_token']);
 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -80,7 +80,7 @@ class EventController extends Controller
         $event = Event::authKeyEquals($request->auth_key)
             ->first();
 
-        if (!is_null($event)) {
+        if (!is_null($event)){
             $pictures = $event->pictures()->get();
 
             $release_date = CarbonImmutable::parse($event->release_date);
@@ -89,8 +89,7 @@ class EventController extends Controller
                 return redirect('events/search')->withErrors('イベントの公開期間外です。');
             }
 
-            if ($pictures->isEmpty())
-            {
+            if ($pictures->isEmpty()) {
                 return view('event_show', [
                     'event' => $event,
                     'pictures' => $pictures,

--- a/yeahcheese/app/Http/Requests/StoreEventRequest.php
+++ b/yeahcheese/app/Http/Requests/StoreEventRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEventRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => ['required', 'max:255'],
+            'release_date' => ['required', 'date', 'after_or_equal:today'],
+            'end_date' => ['required', 'date', 'after:release_date'],
+        ];
+    }
+
+    public function messages()
+    {
+        return[
+            'title.required' => 'イベントタイトルは必須項目です',
+            'title.max' => 'イベントタイトルは255文字まで設定できます',
+
+            'release_date.required' => 'イベント公開開始日は必須項目です',
+            'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
+            'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
+
+            'end_date.required' => 'イベント公開終了日は必須項目です',
+            'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
+            'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
+        ];
+    }
+}

--- a/yeahcheese/app/Http/Requests/StorePictureRequest.php
+++ b/yeahcheese/app/Http/Requests/StorePictureRequest.php
@@ -33,5 +33,4 @@ class StorePictureRequest extends ApiRequest
             'file.between' => '100KB以上、1MB以下の画像にしてください',
         ];
     }
-
 }

--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -36,9 +36,6 @@
                 @if($errors->has('end_date'))
                 <div class="alert alert-danger" role="alert">{{ $errors->first('end_date') }}</div>
                 @endif
-                @if($errors->any())
-                <div class="alert alert-danger" role="alert">入力した値が正しくありません。</div>
-                @endif
                 </div>
 
                 <button type="submit" class="btn btn-primary">作成</button>

--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -17,10 +17,10 @@
                     @csrf
                     <label>イベント名</label>
                     <input type="text" class="form-control" name="title" value="{{ old('title') }}">
+                    @if($errors->has('title'))
+                    <div class="alert alert-danger" role="alert">{{ $errors->first('title') }}</div>
+                    @endif
                 </div>
-                @if($errors->has('title'))
-                <div class="alert alert-danger" role="alert">{{ $errors->first('title') }}</div>
-                @endif
 
                 <div class="form-group">
                     <label>公開開始日</label>


### PR DESCRIPTION
#176 #180 
- Eventのstoreメソッドをフォームリクエストを使うように変更しました
  - Eventモデルのバリデーションは使っている場所がないので削除しました
- 「入力した値が正しくありません」は必要ないので削除しました

レビューよろしくお願いします。