### PR TITLE
日付の更新でエラーが出ない

### DIFF
--- a/yeahcheese/app/Http/Requests/UpdateEventRequest.php
+++ b/yeahcheese/app/Http/Requests/UpdateEventRequest.php
@@ -36,11 +36,11 @@ class UpdateEventRequest extends ApiRequest
 
             'release_date.required' => 'イベント公開開始日は必須項目です',
             'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-            'release_date.before' => 'イベント公開開始日は公開終了日より前の日付である必要があります',
+            'release_date.before' => 'イベント公開開始日は公開終了日以前の日付である必要があります',
 
             'end_date.required' => 'イベント公開終了日は必須項目です',
             'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-            'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
+            'end_date.after' => 'イベント公開終了日はイベント公開開始日以降の日付である必要があります',
         ];
     }
 }

--- a/yeahcheese/app/Http/Requests/UpdateEventRequest.php
+++ b/yeahcheese/app/Http/Requests/UpdateEventRequest.php
@@ -36,11 +36,11 @@ class UpdateEventRequest extends ApiRequest
 
             'release_date.required' => 'イベント公開開始日は必須項目です',
             'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-            'release_date.before' => 'イベント公開開始日は公開終了日以前の日付である必要があります',
+            'release_date.before_or_equal' => 'イベント公開開始日は公開終了日以前の日付である必要があります',
 
             'end_date.required' => 'イベント公開終了日は必須項目です',
             'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-            'end_date.after' => 'イベント公開終了日はイベント公開開始日以降の日付である必要があります',
+            'end_date.after_or_equal' => 'イベント公開終了日はイベント公開開始日以降の日付である必要があります',
         ];
     }
 }

--- a/yeahcheese/app/Http/Requests/UpdateEventRequest.php
+++ b/yeahcheese/app/Http/Requests/UpdateEventRequest.php
@@ -23,8 +23,8 @@ class UpdateEventRequest extends ApiRequest
     {
         return [
             'title' => ['max:255'],
-            'release_date' => ['date', 'before:end_date'],
-            'end_date' => ['date', 'after:release_date'],
+            'release_date' => ['date', 'before_or_equal:end_date'],
+            'end_date' => ['date', 'after_or_equal:release_date'],
         ];
     }
 

--- a/yeahcheese/resources/js/components/EventEditorComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditorComponent.vue
@@ -84,7 +84,7 @@ export default {
     },
   },
   methods: {
-    updateEvent: function() { 
+    updateEvent: function() {
       const request = {
         id : this.eventId,
         title : this.title,

--- a/yeahcheese/tests/Feature/Api/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/EventControllerTest.php
@@ -93,7 +93,7 @@ class EventControllerTest extends TestCase
         $response->assertJson([
             'messages' => [
                 'title' => ['イベントタイトルは255文字まで設定できます'],
-                'release_date' => ['イベント公開開始日は公開終了日より前の日付である必要があります'],
+                'release_date' => ['イベント公開開始日は公開終了日以前の日付である必要があります'],
             ]
         ]);
     }
@@ -137,7 +137,7 @@ class EventControllerTest extends TestCase
 
         $response->assertJson([
             'messages' => [
-                'release_date' => ['イベント公開開始日は公開終了日より前の日付である必要があります'],
+                'release_date' => ['イベント公開開始日は公開終了日以前の日付である必要があります'],
             ]
         ]);
     }
@@ -159,7 +159,7 @@ class EventControllerTest extends TestCase
 
         $response->assertJson([
             'messages' => [
-                'end_date' => ['イベント公開終了日はイベント公開開始日より後の日付である必要があります'],
+                'end_date' => ['イベント公開終了日はイベント公開開始日以降の日付である必要があります'],
             ]
         ]);
     }


### PR DESCRIPTION
#174 
今日から今日が掲載期間のイベントを作れるように変更しました。
別issue(#194 )でイベント作成のときも公開開始日が今日以前にできるように変更します。

レビューよろしくお願いします
