### PR TITLE
公開開始日を今日より前にできるように変更

### DIFF
--- a/yeahcheese/app/Http/Requests/StoreEventRequest.php
+++ b/yeahcheese/app/Http/Requests/StoreEventRequest.php
@@ -25,8 +25,8 @@ class StoreEventRequest extends FormRequest
     {
         return [
             'title' => ['required', 'max:255'],
-            'release_date' => ['required', 'date', 'after_or_equal:today'],
-            'end_date' => ['required', 'date', 'after:release_date'],
+            'release_date' => ['required', 'date', 'before_or_equal:end_date'],
+            'end_date' => ['required', 'date', 'after_or_equal:release_date'],
         ];
     }
 
@@ -38,11 +38,11 @@ class StoreEventRequest extends FormRequest
 
             'release_date.required' => 'イベント公開開始日は必須項目です',
             'release_date.date' => 'イベント公開開始日は日付形式で入力してください',
-            'release_date.after_or_equal' => 'イベント公開開始日は本日以降の日付である必要があります',
+            'release_date.before_or_equal' => 'イベント公開開始日は公開終了日以前の日付である必要があります',
 
             'end_date.required' => 'イベント公開終了日は必須項目です',
             'end_date.date' => 'イベント公開終了日は日付形式で入力してください',
-            'end_date.after' => 'イベント公開終了日はイベント公開開始日より後の日付である必要があります',
+            'end_date.after_or_equal' => 'イベント公開終了日はイベント公開開始日以降の日付である必要があります',
         ];
     }
 }


### PR DESCRIPTION
#194 
イベント編集の際は、公開開始日が今日以前でもOKだったので
それに合わせてイベント作成の際も公開開始日が今日以前でもOKにしました。

StoreEventRequestとUpdateEventRequestを１つにまとめようと思いましたが、Updateにはrequiredがないためやめました。

レビューよろしくお願いします