### PR TITLE
jumbotron内テキストを変更

### DIFF
--- a/yeahcheese/resources/views/event_create.blade.php
+++ b/yeahcheese/resources/views/event_create.blade.php
@@ -6,7 +6,7 @@
 <div class="container">
     <div class="jumbotron bg-white border">
         <h2>イベント作成</h2>
-        <p class="text-secondary">イベントの公開期間は今日以降の日付を指定してください。</p>
+        <p class="text-secondary">イベント情報を入力してイベントを作成しましょう。イベントの写真はイベントを編集する際に登録することができます。</p>
     </div>
 
     <div class="row my-2">

--- a/yeahcheese/resources/views/event_show.blade.php
+++ b/yeahcheese/resources/views/event_show.blade.php
@@ -7,7 +7,9 @@
     <div class="jumbotron bg-white border">
         <h2>{{ $event->title }}</h2>
         <p>掲載期間 : {{ $event->release_date }} / {{ $event->end_date }}</p>
-        <p class="text-secondary">画像をクリックすると拡大表示されます</p>
+        @if (!$errors->any())
+            <p class="text-secondary">画像をクリックすると拡大表示されます</p>
+        @endif
     </div>
 
     <div class="container">

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -6,7 +6,7 @@
 <div class="container">
     <div class="jumbotron bg-white border">
         <h2>イベント閲覧</h2>
-        <p class="text-secondary">イベントの認証キーを入力するとイベントを閲覧することができます</p>
+        <p class="text-secondary">イベントの認証キーを入力するとイベントを閲覧することができます。</p>
     </div>
 
     <div class="row">

--- a/yeahcheese/resources/views/search.blade.php
+++ b/yeahcheese/resources/views/search.blade.php
@@ -19,7 +19,7 @@
         <!-- フォームとボタンだけinlineになるように修正する -->
         <div class="col-md-6 offset-md-3">
             <form method="GET" action="{{ route('events.show') }}">
-                <label>認証キー</label>
+                <h4>認証キー</h4>
                 <div class="form-group form-row form-inline">
                     <input type="text" class="form-control col" name="auth_key" placeholder="認証キーを入力">
                     <button type="submit" class="btn btn-primary mx-2">閲覧</button>


### PR DESCRIPTION
#205 
- イベント作成時に公開開始日が今日からじゃなくても作成できるようになるので変更
- イベント閲覧時に画像が登録されてない場合、画像をクリックすると拡大表示しますのテキストが表示されないように変更
- 認証キー入力画面で句読点がなかったところを追加
- 認証キーの文字がlabelだとあまりに小さいのでh4に変更