### PR TITLE
イベント表示画面の表示テスト

### DIFF
--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -62,8 +62,17 @@ class EventControllerTest extends TestCase
         $response = $this->get('events/show');
 
         $response->assertStatus(302)
-            ->assertRedirect('events/search');
+                 ->assertRedirect('events/search');
     }
+
+    public function testEventShowAuthKeyNotFound()
+    {
+        $response = $this->get('/events/show?auth_key=dummyauthkey');
+
+        $response->assertStatus(302)
+                 ->assertRedirect('events/search');
+    }
+
 
     public function testEventSearch()
     {

--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -55,7 +55,8 @@ class EventControllerTest extends TestCase
                  ->assertSee($event->end_date)
                  ->assertSee($picture->path);
 
-        /* イベントが見つからずリダイレクトした時のテスト
+        /*
+         * イベントが見つからずリダイレクトした時のテスト
          * いまはコンフリクトすると思うのでここに。あとで分離したい
          */
         $response = $this->get('events/show');

--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -55,13 +55,14 @@ class EventControllerTest extends TestCase
                  ->assertSee($event->end_date)
                  ->assertSee($picture->path);
 
-        /*
-         * イベントが見つからずリダイレクトした時のテスト
-         * いまはコンフリクトすると思うのでここに。あとで分離したい
-         */
+    }
+
+    public function testEventShowWithoutAuthKey()
+    {
         $response = $this->get('events/show');
 
-        $response->assertStatus(302);
+        $response->assertStatus(302)
+            ->assertRedirect('events/search');
     }
 
     public function testEventSearch()

--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -6,8 +6,19 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
+use App\Event;
+use App\Picture;
+
 class EventControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
     /**
      * A basic feature test example.
      *
@@ -32,10 +43,24 @@ class EventControllerTest extends TestCase
 
     public function testEventShow()
     {
-        // /events/show?auth_key={}
-        $response = $this->get('/');
+        $event = Event::find(1);
+        $picture = $event->pictures()->first();
+
+        $response = $this->get('/events/show?auth_key=' . $event->auth_key);
 
         $response->assertStatus(200);
+
+        $response->assertSee($event->title)
+                 ->assertSee($event->release_date)
+                 ->assertSee($event->end_date)
+                 ->assertSee($picture->path);
+
+        /* イベントが見つからずリダイレクトした時のテスト
+         * いまはコンフリクトすると思うのでここに。あとで分離したい
+         */
+        $response = $this->get('events/show');
+
+        $response->assertStatus(302);
     }
 
     public function testEventSearch()

--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -73,7 +73,7 @@ class EventControllerTest extends TestCase
                  ->assertRedirect('events/search');
     }
 
-    public function testEventShowAuthKeyNotFound()
+    public function testEventShowWithInvalidAuthKey()
     {
         $response = $this->get('/events/show?auth_key=dummyauthkey');
 


### PR DESCRIPTION
イベント表示画面(events/show)に接続した時の表示とリダイレクトのテストを作成しました。

下記内容をテストしています
- 正しいauth_keyが与えられた時、event内容が表示されている
- 無効なauth_keyが与えられた時、events/searchにリダイレクトする
- auth_keyなしで接続された時、events/searchにリダイレクトする

手元の環境で動作を確認しています。
レビューよろしくお願いいたします。