### PR TITLE
不正な値のまま何度も更新ボタンを押すと同一内容のエラーメッセージが増えるバグを修正

### DIFF
--- a/yeahcheese/resources/js/components/EventEditorComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditorComponent.vue
@@ -198,6 +198,8 @@ export default {
             const responseDataProperties = Object.getOwnPropertyNames(updateResponse.data);
             const responseData = updateResponse.data;
             
+            this.errorMessages = [];
+
             if (responseDataProperties.includes("messages")) {
               const responseErrors = responseData.messages;
 
@@ -209,7 +211,6 @@ export default {
               return;
             }
 
-            this.errorMessages = [];
             this.postStatusMessage = this.postStatusMessages.success;
           },
         )

--- a/yeahcheese/resources/js/components/EventEditorComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditorComponent.vue
@@ -202,7 +202,7 @@ export default {
               const responseErrors = responseData.messages;
 
               for (var error in responseErrors) {
-                console.log(responseErrors[error].toString());
+                console.error(responseErrors[error].toString());
                 this.errorMessages.push(responseErrors[error].toString());
               }
 


### PR DESCRIPTION
イベント更新画面において開発者ツールなどを使い不正な値のリクエストを何度も送信した場合、同一内容のエラーメッセージが増えるバグを修正しました。

参考画像:
![スクリーンショット 2020-05-29 12 37 07](https://user-images.githubusercontent.com/48560146/83219177-a43a0700-a1aa-11ea-8a57-a53d53a046b8.png)

- updateEventでLaravel側からレスポンスを受け取るたびにエラーメッセージを格納している変数を空にするように変更しました
- 今回の修正とはあまり関係ありませんが、コンソールにエラーを表示する際にconsole.errorではなくconsole.logを使用していたのを修正しました

手元の環境で動作確認をしています。
レビューよろしくお願いいたします。