### PR TITLE
EventControllerTest.phpの規約違反部分を修正

### DIFF
--- a/yeahcheese/tests/Feature/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/EventControllerTest.php
@@ -62,7 +62,6 @@ class EventControllerTest extends TestCase
                  ->assertSee($event->release_date)
                  ->assertSee($event->end_date)
                  ->assertSee($picture->path);
-
     }
 
     public function testEventShowWithoutAuthKey()


### PR DESCRIPTION
EventControllerTest.php内に規約違反になっている部分があったため修正しました。

変更内容は下記の通りです
- 空行が存在していたので削除

手元の環境でphpcsを走らせ、該当部分の警告が消えていることを確認しています。
レビューよろしくお願いいたします。