### PR TITLE
イベント編集画面で日付を正しい公開範囲に変更しても更新できない不具合が発生していたのを修正

### DIFF
--- a/yeahcheese/resources/js/components/EventEditorComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditorComponent.vue
@@ -147,6 +147,7 @@ export default {
         this.validateStatus.title = true;
         return;
       }
+
       this.validateStatus.title = false;
     },
     release_date: function (newDate) {
@@ -156,6 +157,7 @@ export default {
       }
 
       this.validateStatus.releaseDate = true;
+      this.validateStatus.endDate = true;
     },
     end_date: function (newDate) {
       if ( Date.parse(newDate) < Date.parse(this.release_date) ) {
@@ -164,6 +166,7 @@ export default {
       }
 
       this.validateStatus.endDate = true;
+      this.validateStatus.releaseDate = true;
     },
   },
   created: function () {
@@ -197,7 +200,7 @@ export default {
           updateResponse => {
             const responseDataProperties = Object.getOwnPropertyNames(updateResponse.data);
             const responseData = updateResponse.data;
-            
+
             if (responseDataProperties.includes("messages")) {
               const responseErrors = responseData.messages;
 


### PR DESCRIPTION
公開開始日と公開終了日のバリデーションの状態が同期されていなかったため、バリデーションエラーが発生した際に片方の日付を修正して正しい公開範囲に変更しても、もう片方の日付バリデーションの状態が変更されず、更新リクエストを送信できない不具合が発生していたのを修正しました。

手元の環境で動作を確認していますが、急ぎの修正だったため確認漏れがあるかもしれません。
レビューよろしくお願いいたします。